### PR TITLE
fix README.md and update surge

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Here's what it uses:
 - Uses [autoprefixer-stylus](https://www.npmjs.com/package/autoprefixer-stylus) to seemlessly insert those pesky `-moz`, `-webkit` prefixes where required.
 - Use GitHub's [Octicon](https://octicons.github.com/) icon set
   - Installed via npm just like other assets.
-  - required in `/src/app.js` with this line `import octicons from 'octicons/octicons/octicons.css'`
+  - required in `/src/app.js` with this line `require('octicons/octicons/octicons.css')`
   - Thanks to the [webpack file-loader](https://github.com/webpack/file-loader#file-loader-for-webpack) as configured in [hjs-webpack](https://github.com/henrikjoreteg/hjs-webpack) the icon fonts are inlined as base64 so you don't have to think about relative URLs in CSS. No manually copying assets into output directory needed, just npm install and require CSS.
 - We use React as the view layer.
 - We do partial isomorphic rendering by statically pre-rendering the React component used for layout on the front end, as well as the logged out homepage view. So, most of the benefits of isomorphic apps, but none of the complexity of trying to dynamically render client code on the server.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "standard": "^3.3.0",
     "style-loader": "^0.9.0",
     "stylus-loader": "^1.0.0",
-    "surge": "^0.8.1",
+    "surge": "^0.13.0",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.3",
     "webpack-dev-server": "^1.8.0",


### PR DESCRIPTION
surge.sh ver 0.8.1 can not deploy octicon's files which name used hash.

in README.md, fixed form "import octicons from 'octicons/octicons/octicons.css'" to "require('octicons/octicons/octicons.css')" .
