### PR TITLE
Fix a misspelled function name reference in the me model

### DIFF
--- a/src/models/me.js
+++ b/src/models/me.js
@@ -20,7 +20,7 @@ export default Model.extend(githubMixin, {
     repos: RepoCollection
   },
 
-  onChangeToken () {
+  onTokenChange () {
     window.localStorage.token = this.token
     this.fetchInitialData()
   },


### PR DESCRIPTION
In the me.js model's initialize method, a onTokenChange function is referenced. On the model object the function is spelled onChangeToken. This PR simply renames onChangeToken to onTokenChange.
